### PR TITLE
python 3 compatibility

### DIFF
--- a/ximage.py
+++ b/ximage.py
@@ -9,6 +9,7 @@ from hashlib import sha1
 from datetime import datetime
 from string import Template
 import pickle
+from functools import reduce
 
 XMP_NS_ALIQUIS = 'http://bioretics.com/aliquis'
 
@@ -361,7 +362,8 @@ def ximage_import(args):
         for root in roots:
             parent.children.append(root)
             build_hierarchy(blobs_children, root)
-
+            
+            
     mask = cv2.imread(args.mask, -1)
 
     # Count number of classes
@@ -565,7 +567,7 @@ def _ximage_index_connect(args, create=False):
     sqlite3.register_converter('uuid', lambda buf: UUID(bytes=buf))
     sqlite3.register_adapter(XValue, lambda x: pickle.dumps(x.val))
     sqlite3.register_adapter(np.ndarray, lambda a: np.getbuffer(a))
-    sqlite3.register_adapter(UUID, lambda uuid: buffer(uuid.get_bytes()))
+    sqlite3.register_adapter(UUID, lambda uuid: memoryview(uuid.get_bytes()))
 
     index_path = os.path.join(args.root, '.ximage-index.db')
     if not create:

--- a/ximage.py
+++ b/ximage.py
@@ -363,7 +363,6 @@ def ximage_import(args):
             parent.children.append(root)
             build_hierarchy(blobs_children, root)
             
-            
     mask = cv2.imread(args.mask, -1)
 
     # Count number of classes
@@ -567,7 +566,11 @@ def _ximage_index_connect(args, create=False):
     sqlite3.register_converter('uuid', lambda buf: UUID(bytes=buf))
     sqlite3.register_adapter(XValue, lambda x: pickle.dumps(x.val))
     sqlite3.register_adapter(np.ndarray, lambda a: np.getbuffer(a))
-    sqlite3.register_adapter(UUID, lambda uuid: memoryview(uuid.get_bytes()))
+    
+    if sys.version_info[0] == 2:
+        sqlite3.register_adapter(UUID, lambda uuid: buffer(uuid.get_bytes()))
+    else:
+        sqlite3.register_adapter(UUID, lambda uuid: memoryview(uuid.get_bytes()))
 
     index_path = os.path.join(args.root, '.ximage-index.db')
     if not create:

--- a/ximage.py
+++ b/ximage.py
@@ -914,7 +914,12 @@ def ximage_main(prog_name='ximage'):
     parser_stats = subparsers.add_parser('stats', help='Show some indexed directory statistics')
     parser_stats.add_argument('-D', '--root', type=str, required=False, default=os.getcwd(), help='Root directory path (default: cwd)')
     parser_stats.set_defaults(func=ximage_stats)
-
+    
+    # print usage if no args are used
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+        
     args = parser.parse_args()
     sys.exit(args.func(args))
 


### PR DESCRIPTION
- resolved two functionality-breaking issues in python 3 for ximage_import and ximage_index
- display usage when ximage is launched without arguments